### PR TITLE
Fixed flatDir reference

### DIFF
--- a/src/android/plugin.gradle
+++ b/src/android/plugin.gradle
@@ -1,7 +1,7 @@
 repositories{    
   jcenter()
   flatDir {
-      dirs 'libs'
+      dirs 'src/main/libs'
    }
 }
 


### PR DESCRIPTION
Fixed issue with flatDir reference in plugin.gradle file so that you don't have to manually copy the DataCollection.aar file to app/libs